### PR TITLE
Add GitHub composite action for generating version diffs

### DIFF
--- a/.github/actions/generate-diff/action.yml
+++ b/.github/actions/generate-diff/action.yml
@@ -1,0 +1,118 @@
+name: 'Generate Diff'
+description: 'Generate diffs between header files using cheader2json'
+
+inputs:
+  pypi-version:
+    description: 'The published PyPI version number to use. If not provided, the latest published version will be used. If set to a commit hash or a string such as `main`, the corresponding branch of the cheader2json repository will be used.'
+    required: false
+    default: 'latest'
+  repository-url:
+    description: 'The URL of the Git repository to generate the diff for.'
+    required: true
+  old-version:
+    description: 'The specific old version number to generate the diff for.'
+    required: false
+  new-version:
+    description: 'The specific new version number to generate the diff for.'
+    required: false
+  version-constraint:
+    description: 'A custom version constraint pattern using regular expressions.'
+    required: false
+  header-paths:
+    description: 'A path or regex within the source code checkouts to get the header files that should be converted to JSON.'
+    required: true
+
+outputs:
+  diff-output:
+    description: 'The results of the diff for use by other steps in a larger GitHub Actions workflow.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository-url }}
+        ref: ${{ inputs.pypi-version }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install cheader2json
+      run: |
+        if [ "${{ inputs.pypi-version }}" == "latest" ]; then
+          pip install cheader2json
+        else
+          pip install cheader2json==${{ inputs.pypi-version }}
+        fi
+
+    - name: Fetch tags
+      run: |
+        git fetch --tags
+
+    - name: Determine versions
+      id: determine-versions
+      run: |
+        if [ -z "${{ inputs.old-version }}" ] || [ -z "${{ inputs.new-version }}" ]; then
+          tags=$(git tag -l --sort=-v:refname)
+          if [ -n "${{ inputs.version-constraint }}" ]; then
+            tags=$(echo "$tags" | grep -E "${{ inputs.version-constraint }}")
+          fi
+          if [ -z "${{ inputs.old-version }}" ]; then
+            old_version=$(echo "$tags" | sed -n '2p')
+          else
+            old_version=${{ inputs.old-version }}
+          fi
+          if [ -z "${{ inputs.new-version }}" ]; then
+            new_version=$(echo "$tags" | sed -n '1p')
+          else
+            new_version=${{ inputs.new-version }}
+          fi
+        else
+          old_version=${{ inputs.old-version }}
+          new_version=${{ inputs.new-version }}
+        fi
+        echo "old_version=$old_version" >> $GITHUB_ENV
+        echo "new_version=$new_version" >> $GITHUB_ENV
+
+    - name: Checkout old version
+      run: |
+        git checkout ${{ env.old_version }}
+
+    - name: Convert old version headers to JSON
+      run: |
+        cheader2json convert ${{ inputs.header-paths }} --prefix=${{ env.old_version }}
+
+    - name: Checkout new version
+      run: |
+        git checkout ${{ env.new_version }}
+
+    - name: Convert new version headers to JSON
+      run: |
+        cheader2json convert ${{ inputs.header-paths }} --prefix=${{ env.new_version }}
+
+    - name: Generate diff
+      run: |
+        cheader2json diff ${{ env.old_version }}.ast.json ${{ env.new_version }}.ast.json > diff-output.txt
+
+    - name: Upload JSON files
+      uses: actions/upload-artifact@v4
+      with:
+        name: json-files
+        path: |
+          ${{ env.old_version }}.ast.json
+          ${{ env.old_version }}.types.json
+          ${{ env.new_version }}.ast.json
+          ${{ env.new_version }}.types.json
+
+    - name: Upload diff results
+      uses: actions/upload-artifact@v4
+      with:
+        name: diff-results
+        path: diff-output.txt
+
+    - name: Set diff output
+      id: set-diff-output
+      run: echo "diff-output=$(cat diff-output.txt)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,17 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      old-version:
+        description: 'Override the old version for HELICS'
+        required: false
+      new-version:
+        description: 'Override the new version for HELICS'
+        required: false
+      version-constraint:
+        description: 'Optional version constraint for HELICS versions'
+        required: false
 
 jobs:
   build:
@@ -39,3 +50,17 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         path: "*.json"
+
+  generate-diff:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Generate Diff
+      uses: ./.github/actions/generate-diff
+      with:
+        pypi-version: 'latest'
+        repository-url: 'https://github.com/GMLC-TDC/HELICS.git'
+        old-version: ${{ github.event.inputs.old-version || '' }}
+        new-version: ${{ github.event.inputs.new-version || '' }}
+        version-constraint: ${{ github.event.inputs.version-constraint || '^v3.*' }}
+        header-paths: 'src/helics/shared_api_library/backup/helics/helics.h'

--- a/README.md
+++ b/README.md
@@ -34,3 +34,34 @@ Do a diff of two dumped AST JSON files:
 ```shell
 cheader2json diff <JSON_AST_FILE_OLD> <JSON_AST_FILE_NEW>
 ```
+
+## GitHub Composite Action
+
+A GitHub composite action is available to generate diffs between header files using the cheader2json package. This action can be reused in other repositories to automate the process of generating diffs.
+
+### Inputs
+
+- `pypi-version` (optional): The published PyPI version number to use. If not provided, the latest published version will be used. If set to a commit hash or a string such as `main`, the corresponding branch of the cheader2json repository will be used.
+- `repository-url` (required): The URL of the Git repository to generate the diff for.
+- `old-version` (optional): The specific old version number to generate the diff for.
+- `new-version` (optional): The specific new version number to generate the diff for.
+- `version-constraint` (optional): A custom version constraint pattern using regular expressions.
+- `header-paths` (required): A path or regex within the source code checkouts to get the header files that should be converted to JSON.
+
+### Outputs
+
+- `diff-output`: The results of the diff for use by other steps in a larger GitHub Actions workflow.
+
+### Example Generate Diff Step
+
+```yaml
+- name: Generate Diff
+  uses: ./.github/actions/generate-diff
+  with:
+    pypi-version: 'latest'
+    repository-url: 'https://github.com/GMLC-TDC/HELICS.git'
+    old-version: 'v3.0.0'
+    new-version: 'v3.1.0'
+    version-constraint: '^v3.*'
+    header-paths: 'include/**/*.h'
+```


### PR DESCRIPTION
Fixes #93

Add a new GitHub composite action to generate diffs between header files using the cheader2json package.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GMLC-TDC/cheader2json/pull/95?shareId=f856bb11-c372-45e8-9aad-d4b233bbd3c1).